### PR TITLE
Fallback if args is empty

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -277,7 +277,7 @@ class ListenerThread(Thread):
     def on_event(self, packetID, channelName, data):
         valueByName = loads(data)
         eventName = valueByName['name']
-        eventArguments = valueByName['args']
+        eventArguments = valueByName.get('args', [])
         callback = self.get_callback(channelName, eventName)
         callback(*eventArguments)
 


### PR DESCRIPTION
Some projects that use socket.io, e.g. http://deployd.com/, don't always send the args parameter, which will result in a KeyError.
