### PR TITLE
socketIO-client does not properly detect and process websocket disconnect

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -219,6 +219,8 @@ class _ListenerThread(Thread):
             except SocketIOConnectionError, error:
                 print error
                 self.cancel()
+                # Notify connection error
+                self._socketIO.disconnect()
                 break
             except SocketIOPacketError, error:
                 print error


### PR DESCRIPTION
When remote server (on websocket connection) terminates, the current client only prints a "Lost connection (Connection closed)" message. I have a namespace with on_disconnect() but it's not called. Furthermore, my SocketIO object sio with sio.wait() will not terminate either. Current client will print out "Could not send heartbeat" forever.

I have two suggestions:
1. The lost connection should trigger an on_disconnect() call, otherwise user will never know when a connection is terminated.
2. The "Could not send heartbeat" should not retry forever. It should do something sane (like closing the websocket) after (several?) timeouts.
