### PR TITLE
Pass on wait timeout to underlying transports

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -172,7 +172,7 @@ class SocketIO(object):
             for elapsed_time in warning_screen:
                 try:
                     try:
-                        self._process_events()
+                        self._process_events(timeout=seconds)
                     except TimeoutError:
                         pass
                     if self._stop_waiting(for_callbacks):
@@ -188,8 +188,8 @@ class SocketIO(object):
         except KeyboardInterrupt:
             pass
 
-    def _process_events(self):
-        for packet in self._transport.recv_packet():
+    def _process_events(self, timeout=None):
+        for packet in self._transport.recv_packet(timeout=timeout):
             try:
                 self._process_packet(packet)
             except PacketError as e:


### PR DESCRIPTION
When you wish to wait for anything below the default timeout (3 seconds) , the wait function does not (necessarily) return in 3 seconds.