### PR TITLE
Catch AttributeError in client connected check

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -222,7 +222,12 @@ class SocketIO(object):
 
     @property
     def connected(self):
-        return self.__transport.connected
+        try:
+            transport = self.__transport
+        except AttributeError:
+            return False
+        else:
+            return transport.connected
 
     @property
     def _transport(self):


### PR DESCRIPTION
If the client has never connected, there will be no __transport attribute.