### PR TITLE
Make on_reconnect callback functional

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -25,6 +25,7 @@ class BaseNamespace(object):
     def __init__(self, _transport, path):
         self._transport = _transport
         self.path = path
+        self.was_connected = False
         self._callback_by_event = {}
         self.initialize()
 
@@ -101,6 +102,15 @@ class BaseNamespace(object):
             return self._callback_by_event[event]
         except KeyError:
             pass
+
+        # Convert connect to reconnect if we have seen connect
+        # already.
+        if event == 'connect':
+            if self.was_connected == False:
+                self.was_connected = True
+            else:
+                event = 'reconnect'
+
         # Check callbacks defined explicitly or use on_event()
         return getattr(
             self,


### PR DESCRIPTION
Previously, if the socket.io connection got interrupted and reconnected
the on_connect callback got called again. I noticed that there is a
on_reconnect function to overide in the base namespace class, but since
there is no socket.io command corresponding to on_reconnect it never
gets called.

This commit adds a check to see if we have been connected before, and if
so, calls the on_reconnect callback instead of the on_connect callback agin.