### PR TITLE
Use HTTP headers for Websocket connection

### DIFF
--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -121,8 +121,13 @@ class _WebsocketTransport(_AbstractTransport):
         url = '%s://%s/websocket/%s' % (
             'wss' if is_secure else 'ws',
             base_url, socketIO_session.id)
+
+        http_session = _prepare_http_session(kw)
+        req = http_session.prepare_request(requests.Request('GET', url))
+        headers = ['%s: %s' % item for item in req.headers.iteritems()]
+
         try:
-            self._connection = websocket.create_connection(url)
+            self._connection = websocket.create_connection(url, header=headers)
         except socket.timeout as e:
             raise ConnectionError(e)
         except socket.error as e:


### PR DESCRIPTION
Websocket connection does not currently make use of the kwargs provided in SocketIO constructor (cookies, etc.). This makes cookie-based authentication impossible for example.

A solution is to create a fake request to resolve headers.