### PR TITLE
Support unicode data in emit

### DIFF
--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -66,7 +66,7 @@ class _AbstractTransport(object):
 
     def send_packet(self, code, path='', data='', callback=None):
         packet_id = self.set_ack_callback(callback) if callback else ''
-        packet_parts = str(code), packet_id, path, data
+        packet_parts = str(code), packet_id, path, unicode(data).encode('utf-8')
         packet_text = ':'.join(packet_parts)
         self.send(packet_text)
         _log.debug('[packet sent] %s', packet_text)


### PR DESCRIPTION
In xhr-polling context, using emit with unicode data will throw an encoding error :
```
UnicodeEncodeError: 'ascii' codec can't encode character u'\xc9' in position 126: ordinal not in range(128)
```

Multiple solutions :
1. Change python requests (or other sublib) to make it force data encoding to utf-8
2. Remove ensure_ascii from json.dumps and let json.dumps create ascii data
3. Force packets encoding to utf-8 instead of unicode object

This problem does not exist with websocket transport because websocket-client force encoding to utf-8 when passed unicode objects.
