### PR TITLE
allow to pass in a different resource than just 'socket.io'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,8 @@ Specify params, headers, cookies, proxies thanks to the `requests`_ library. ::
     from socketIO_client import SocketIO
     from base64 import b64encode
 
-    SocketIO('localhost', 8000, 
+    SocketIO('localhost', 8000,
+        resource='my.io',
         params={'q': 'qqq'},
         headers={'Authorization': 'Basic ' + b64encode('username:password')},
         cookies={'a': 'aaa'},
@@ -149,7 +150,7 @@ Credits
 - `Paul Kienzle`_, `Zac Lee`_, `Josh VanderLinden`_, `Ian Fitzpatrick`_, `Lucas Klein`_, `Rui Chicoria`_, `Travis Odom`_ submitted code to expand support of the socket.io protocol.
 - `Bernard Pratz`_ and `Francis Bull`_ wrote prototypes to support xhr-polling and jsonp-polling.
 - `Eric Chen`_, `Denis Zinevich`_, `Thiago Hersan`_, `Nayef Copty`_ suggested ways to make the connection more robust.
-  
+
 
 .. _socket.io: http://socket.io
 .. _requests: http://python-requests.org
@@ -175,8 +176,8 @@ Credits
 .. _Lucas Klein: https://github.com/lukashed
 .. _Rui Chicoria: https://github.com/rchicoria
 .. _Travis Odom: https://github.com/burstaholic
-
 .. _Eric Chen: https://github.com/taiyangc
-.. _Denis Zinevich: https://github.com/dzinevich 
+.. _Denis Zinevich: https://github.com/dzinevich
 .. _Thiago Hersan: https://github.com/thiagohersan
 .. _Nayef Copty: https://github.com/nayefc
+.. _Patrick Huber: https://github.com/stackmagic

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -20,6 +20,7 @@ RETRY_INTERVAL_IN_SECONDS = 1
 
 
 class BaseNamespace(object):
+
     'Define client behavior'
 
     def __init__(self, _transport, path):
@@ -109,6 +110,7 @@ class BaseNamespace(object):
 
 
 class SocketIO(object):
+
     """Create a socket.io client that connects to a socket.io server
     at the specified host and port.
 
@@ -119,6 +121,7 @@ class SocketIO(object):
     - Pass query params, headers, cookies, proxies as keyword arguments.
 
     SocketIO('localhost', 8000,
+        resource='my.io',
         params={'q': 'qqq'},
         headers={'Authorization': 'Basic ' + b64encode('username:password')},
         cookies={'a': 'aaa'},
@@ -127,8 +130,8 @@ class SocketIO(object):
 
     def __init__(
             self, host, port=None, Namespace=BaseNamespace,
-            wait_for_connection=True, transports=TRANSPORTS, **kw):
-        self.is_secure, self.base_url = _parse_host(host, port)
+            wait_for_connection=True, transports=TRANSPORTS, resource='socket.io', **kw):
+        self.is_secure, self.base_url = _parse_host(host, port, resource)
         self.wait_for_connection = wait_for_connection
         self._namespace_by_path = {}
         self.client_supported_transports = transports
@@ -361,14 +364,14 @@ def find_callback(args, kw=None):
         return None, args
 
 
-def _parse_host(host, port):
+def _parse_host(host, port, resource):
     if not host.startswith('http'):
         host = 'http://' + host
     url_pack = urlparse(host)
     is_secure = url_pack.scheme == 'https'
     port = port or url_pack.port or (443 if is_secure else 80)
-    base_url = '%s:%d%s/socket.io/%s' % (
-        url_pack.hostname, port, url_pack.path, PROTOCOL_VERSION)
+    base_url = '%s:%d%s/%s/%s' % (
+        url_pack.hostname, port, url_pack.path, resource, PROTOCOL_VERSION)
     return is_secure, base_url
 
 


### PR DESCRIPTION
Most socket.io servers run at /socket.io - which was hardcoded in the client. This change allows to override the location to be whatever one requires it to be.
