### PR TITLE
explicitly set file open to use utf8 encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REQUIREMENTS = [
 
 
 HERE = dirname(abspath(__file__))
-DESCRIPTION = '\n\n'.join(open(join(HERE, _)).read() for _ in [
+DESCRIPTION = '\n\n'.join(open(join(HERE, _), encoding="utf8").read() for _ in [
     'README.rst',
     'CHANGES.rst',
 ])


### PR DESCRIPTION
explicitly set file open to use utf8 encoding when setup.py parses README and CHANGES file.  If this is not done some systems will throw unicode can't decode byte error

This issue occurs when you try to:
python3 setup.py install or install via pip3