### PR TITLE
Solution for issue77

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -173,7 +173,10 @@ class EngineIO(LoggingMixin):
 
     def _close(self):
         self._wants_to_close = True
-        self._heartbeat_thread.halt()
+        try:
+            self._heartbeat_thread.halt()
+        except AttributeError:
+            pass
         if not self._opened:
             return
         engineIO_packet_type = 1


### PR DESCRIPTION
fixing close method that is called as part of __del__. 
No longer throws error trying to call an attribute that will not exist if object fails during instantiation