### PR TITLE
Replaced *args with args.

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -407,6 +407,7 @@ class SocketIO(object):
                 '6': self._on_ack,
                 '7': self._on_error,
                 '8': self._on_noop,
+                '': self._on_noop
             }[code]
         except KeyError:
             raise PacketError('unexpected code (%s)' % code)

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -237,7 +237,7 @@ class SocketIO(object):
         callback, args = find_callback(args, kw)
         self._transport.emit(path, event, args, callback)
 
-    def wait(self, seconds=None, for_callbacks=False):
+    def wait(self, seconds=None, for_callbacks=False, raise_error=False):
         """Wait in a loop and process events as defined in the namespaces.
 
         - Omit seconds, i.e. call wait() without arguments, to wait forever.
@@ -254,6 +254,8 @@ class SocketIO(object):
                     pass
                 next(self._heartbeat_pacemaker)
             except ConnectionError as e:
+                if raise_error:
+                    raise
                 try:
                     warning = Exception('[connection error] %s' % e)
                     warning_screen.throw(warning)

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -274,7 +274,7 @@ class SocketIO(object):
 
     def _process_packet(self, packet):
         code, packet_id, path, data = packet
-        namespace = self.get_namespace(path)
+        namespace = self.get_namespace(path or '')
         delegate = self._get_delegate(code)
         delegate(packet, namespace._find_event_callback)
 

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -237,7 +237,7 @@ class SocketIO(object):
         callback, args = find_callback(args, kw)
         self._transport.emit(path, event, args, callback)
 
-    def wait(self, seconds=None, for_callbacks=False, raise_error=False):
+    def wait(self, seconds=None, for_callbacks=False, on_error=None, error_args=None):
         """Wait in a loop and process events as defined in the namespaces.
 
         - Omit seconds, i.e. call wait() without arguments, to wait forever.
@@ -254,8 +254,8 @@ class SocketIO(object):
                     pass
                 next(self._heartbeat_pacemaker)
             except ConnectionError as e:
-                if raise_error:
-                    raise
+                if on_error is not None and callable(on_error):
+                    on_error(e, error_args)
                 try:
                     warning = Exception('[connection error] %s' % e)
                     warning_screen.throw(warning)

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -315,7 +315,7 @@ class SocketIO(object):
         try:
             if self.connected:
                 return self.__transport
-        except AttributeError:
+        except AttributeError as e:
             pass
         socketIO_session = self._get_socketIO_session()
         supported_transports = self._get_supported_transports(socketIO_session)
@@ -396,21 +396,18 @@ class SocketIO(object):
             raise PacketError('unhandled namespace path (%s)' % path)
 
     def _get_delegate(self, code):
-        try:
-            return {
-                '0': self._on_disconnect,
-                '1': self._on_connect,
-                '2': self._on_heartbeat,
-                '3': self._on_message,
-                '4': self._on_json,
-                '5': self._on_event,
-                '6': self._on_ack,
-                '7': self._on_error,
-                '8': self._on_noop,
-                '': self._on_noop
-            }[code]
-        except KeyError:
-            raise PacketError('unexpected code (%s)' % code)
+        return {
+            '0': self._on_disconnect,
+            '1': self._on_connect,
+            '2': self._on_heartbeat,
+            '3': self._on_message,
+            '4': self._on_json,
+            '5': self._on_event,
+            '6': self._on_ack,
+            '7': self._on_error,
+            '8': self._on_noop,
+            '': self._on_noop
+        }.get(code, self._on_noop)
 
     def _on_disconnect(self, packet, find_event_callback):
         find_event_callback('disconnect')()

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -275,7 +275,7 @@ class SocketIO(object):
     def _process_packet(self, packet):
         code, packet_id, path, data = packet
         namespace = self.get_namespace(path or '')
-        delegate = self._get_delegate(code)
+        delegate = self._get_delegate(code, packet)
         delegate(packet, namespace._find_event_callback)
 
     def _stop_waiting(self, for_callbacks):
@@ -395,19 +395,22 @@ class SocketIO(object):
         except KeyError:
             raise PacketError('unhandled namespace path (%s)' % path)
 
-    def _get_delegate(self, code):
-        return {
-            '0': self._on_disconnect,
-            '1': self._on_connect,
-            '2': self._on_heartbeat,
-            '3': self._on_message,
-            '4': self._on_json,
-            '5': self._on_event,
-            '6': self._on_ack,
-            '7': self._on_error,
-            '8': self._on_noop,
-            '': self._on_noop
-        }.get(code, self._on_noop)
+    def _get_delegate(self, code, packet):
+        try:
+            return {
+                '0': self._on_disconnect,
+                '1': self._on_connect,
+                '2': self._on_heartbeat,
+                '3': self._on_message,
+                '4': self._on_json,
+                '5': self._on_event,
+                '6': self._on_ack,
+                '7': self._on_error,
+                '8': self._on_noop,
+                '': self._on_noop
+            }[code]
+        except KeyError:
+            raise PacketError('unexpected code ({}): {}'.format([code], packet))
 
     def _on_disconnect(self, packet, find_event_callback):
         find_event_callback('disconnect')()


### PR DESCRIPTION
*args caused dictionary packets to get stripped of values and
as a result, keys were only left, which is useless.

Given this code example:

``` python
from socketIO_client import SocketIO, LoggingNamespace

def message(*message):
    print 'message:', message

with SocketIO('209.197.176.152', 5555, LoggingNamespace) as socketIO:
    socketIO.on('event', message)
    socketIO.wait()
```

The old code would have taken a packet with this dictionary:

``` python
{'something': 'important_data'}
```

and the output of the callback would have been

``` python
message: ('something',)
```

With the PR, it is correctly this output:

``` python
message: ({'something': 'important_data'},)
```
