### PR TITLE
Moves logging into a namespace.

### DIFF
--- a/socketIO_client/logs.py
+++ b/socketIO_client/logs.py
@@ -2,7 +2,16 @@ import logging
 import time
 
 logger = logging.getLogger("socketIO-client")
-logger.addHandler(logging.NullHandler())
+
+try:
+    logger.addHandler(logging.NullHandler())
+except AttributeError:
+    # Workaround for Python 2.6 not having NullHandler
+    # See https://docs.python.org/release/2.6/library/logging.html#configuring-logging-for-a-library
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+    logger.addHandler(NullHandler())
 
 class LoggingMixin(object):
 

--- a/socketIO_client/logs.py
+++ b/socketIO_client/logs.py
@@ -16,7 +16,7 @@ except AttributeError:
 class LoggingMixin(object):
 
     def _log(self, level, msg, *attrs):
-        logging.log(level, '%s %s' % (self._log_name, msg), *attrs)
+        logger.log(level, '%s %s' % (self._log_name, msg), *attrs)
 
     def _debug(self, msg, *attrs):
         self._log(logging.DEBUG, msg, *attrs)

--- a/socketIO_client/logs.py
+++ b/socketIO_client/logs.py
@@ -1,6 +1,8 @@
 import logging
 import time
 
+logger = logging.getLogger("socketIO-client")
+logger.addHandler(logging.NullHandler())
 
 class LoggingMixin(object):
 


### PR DESCRIPTION
This allows users to selectively control the module's logging behavior independent of the global logging behavior.

I found the debug logging too verbose for my needs most of the time, but still needed debug logs from other parts of the application. Since the module logged directly to the global logger, there was no way to set it to be less verbose while leaving the other parts alone. With this change, users can add something like `logging.getLogger("socketIO-client").setLevel(logging.WARNING)` to their code to reduce the verbosity.