### PR TITLE
use six.u for unicode encoding

### DIFF
--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -153,7 +153,7 @@ class WebsocketTransport(AbstractTransport):
         except socket.error as e:
             raise ConnectionError('recv disconnected (%s)' % e)
         engineIO_packet_type, engineIO_packet_data = parse_packet_text(
-            six.b(packet_text))
+            six.u(packet_text))
         yield engineIO_packet_type, engineIO_packet_data
 
     def send_packet(self, engineIO_packet_type, engineIO_packet_data=''):


### PR DESCRIPTION
Quick fix for #81 
Since utf is widely used and will inevitably come up while interacting via socketIO, using six.u fixes the problem. The method is detailed [here](http://pythonhosted.org/six/)