### PR TITLE
Some socket.io projects send upercased OK

### DIFF
--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -96,7 +96,7 @@ class XHR_PollingTransport(AbstractTransport):
                 params=params,
                 data=memoryview(data),
                 **self._kw_post)
-            assert response.content == b'ok'
+            assert response.content.lower() == b'ok'
 
     def _get_timestamp(self):
         with self._request_index_lock:


### PR DESCRIPTION
Some socket.io are sending the OK upercased, so we need a lower here to understand that.