### PR TITLE
Add LICENSE into distribution archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 recursive-include socketIO_client *
-include *.html *.js *.rst 
+include *.html *.js *.rst LICENSE
 global-exclude *.pyc


### PR DESCRIPTION
The distribution archive on PyPI doesn't include LICENSE file, however inclusion of the license text is required by the license. This makes further distribution a bit difficult.

I'm packaging socketIO-client for Fedora. At the moment, I'm including LICENSE from the repository, otherwise the package wouldn't comply with the license. The [Fedora Licensing Guidelines](https://fedoraproject.org/wiki/Packaging:LicensingGuidelines#License_Text) explain this a bit better than I do.