### PR TITLE
Fix wait() seconds argument with None as value

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -243,7 +243,12 @@ class SocketIO(object):
         - Omit seconds, i.e. call wait() without arguments, to wait forever.
         """
         warning_screen = _yield_warning_screen(seconds)
-        timeout = min(self._heartbeat_interval, seconds)
+
+        if seconds is None:
+            timeout = None
+        else:
+            timeout = min(self._heartbeat_interval, seconds)
+
         for elapsed_time in warning_screen:
             if self._stop_waiting(for_callbacks):
                 break

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -244,10 +244,7 @@ class SocketIO(object):
         """
         warning_screen = _yield_warning_screen(seconds)
 
-        if seconds is None:
-            timeout = None
-        else:
-            timeout = min(self._heartbeat_interval, seconds)
+        timeout = self._get_timeout(seconds)
 
         for elapsed_time in warning_screen:
             if self._stop_waiting(for_callbacks):
@@ -269,6 +266,20 @@ class SocketIO(object):
                     namespace.on_disconnect()
                 except KeyError:
                     pass
+
+    def _get_timeout(self, seconds=None):
+        """
+        return the min value between heartbeat_interval and seconds param
+        if seconds is None, return None instead
+
+        :seconds: None | integer
+        :returns: None | integer
+
+        """
+        if seconds is None:
+            return None
+
+        return min(self._heartbeat_interval, seconds)
 
     def _process_events(self, timeout=None):
         for packet in self._transport.recv_packet(timeout):

--- a/socketIO_client/tests.py
+++ b/socketIO_client/tests.py
@@ -6,7 +6,7 @@ from . import SocketIO, LoggingNamespace, find_callback
 from .transports import TIMEOUT_IN_SECONDS
 
 
-HOST = 'localhost'
+HOST = 'socketio'
 PORT = 8000
 DATA = 'xxx'
 PAYLOAD = {'xxx': 'yyy'}
@@ -184,7 +184,7 @@ class BaseMixin(object):
         """
         timeout = self.socketIO._get_timeout(None)
         self.socketIO._heartbeat_interval = 10
-        self.assertIsNone(timeout)
+        self.assertEqual(None, timeout)
 
         timeout = self.socketIO._get_timeout(3)
         self.assertEqual(3, timeout)

--- a/socketIO_client/tests.py
+++ b/socketIO_client/tests.py
@@ -177,6 +177,18 @@ class BaseMixin(object):
             'ack_callback_response': (PAYLOAD,),
         })
 
+    def test_get_timeout(self):
+        """
+        when _get_timeout is supplied with None, it should return None
+        when supplied with numbers, should return numbers
+        """
+        timeout = self.socketIO._get_timeout(None)
+        self.socketIO._heartbeat_interval = 10
+        self.assertIsNone(timeout)
+
+        timeout = self.socketIO._get_timeout(3)
+        self.assertEqual(3, timeout)
+
 
 class Test_WebsocketTransport(TestCase, BaseMixin):
 


### PR DESCRIPTION
At least for python > 3.4, `min()` does not accept None as argument. If `SocketIO.wait()` is called without argument, the `seconds` param is set to None by default, this causes `min()` to raise Exception.

Since this only effect how `timeout` is set, I've made it into a separate code for easier testing.
