### PR TITLE
Closing connections on EngineIO._close()

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -197,12 +197,15 @@ class EngineIO(LoggingMixin):
         except AttributeError:
             pass
         if not hasattr(self, '_opened') or not self._opened:
+            self._http_session.close()
             return
         engineIO_packet_type = 1
         try:
             self._transport_instance.send_packet(engineIO_packet_type)
         except (TimeoutError, ConnectionError):
             pass
+        self._http_session.close()
+        self._transport_instance.close()
         self._opened = False
 
     def _ping(self, engineIO_packet_data=''):

--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -45,6 +45,9 @@ class AbstractTransport(object):
     def set_timeout(self, seconds=None):
         pass
 
+    def close(self):
+        pass
+
 
 class XHR_PollingTransport(AbstractTransport):
 
@@ -167,6 +170,9 @@ class WebsocketTransport(AbstractTransport):
 
     def set_timeout(self, seconds=None):
         self._connection.settimeout(seconds or self._timeout)
+
+    def close(self):
+        self._connection.close()
 
 
 def get_response(request, *args, **kw):


### PR DESCRIPTION
A socketIO connection can hold two connections open: its transport and its requests.Session instance. These should be closed in `__del__()` and `__exit__()`.

I found that on a Linux system, failure to close the underlying websocket.WebSocket and requests.Session instances causes a file descriptor leak.
