### PR TITLE
Encode received text as utf-8 rather than latin1

### DIFF
--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -151,7 +151,7 @@ class WebsocketTransport(AbstractTransport):
         except SocketError as e:
             raise ConnectionError('recv disconnected (%s)' % e)
         if not isinstance(packet_text, six.binary_type):
-            packet_text = six.b(packet_text)
+            packet_text = packet_text.encode('utf-8')
         engineIO_packet_type, engineIO_packet_data = parse_packet_text(
             packet_text)
         yield engineIO_packet_type, engineIO_packet_data


### PR DESCRIPTION
When utf-8 text is received, the WebsocketTransport was using six.b() to
convert it to bytes. This function assumes the text is latin1. Later the
bytes are decoded back into a string when parse_socketIO_packet_data
calls symmetries.decode_string(). This function assumes the bytes are
utf-8 encoded. Since utf-8 is an almost universal standard it is better to
initially convert using utf-8 instead of latin1.

This pull requests addresses #81 and #122.