### PR TITLE
Emulate disconnect behaviour of disconnect packet

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -263,7 +263,7 @@ class EngineIO(LoggingMixin):
                     self._warn(warning)
                 try:
                     namespace = self.get_namespace()
-                    namespace.on_disconnect()
+                    namespace._find_packet_callback("disconnect")()
                 except PacketError:
                     pass
         self._heartbeat_thread.relax()
@@ -415,7 +415,7 @@ class SocketIO(EngineIO):
                 pass
         try:
             namespace = self._namespace_by_path.pop(path)
-            namespace.on_disconnect()
+            namespace._find_packet_callback("disconnect")()
         except KeyError:
             pass
 


### PR DESCRIPTION
In case of network outages from the client side, `on_disconnect` event cannot be triggered as we don't get any `disconnect` packet from the server. 
Using custom namespace and not default one has the desired behaviour since you can define your own `on_disconnect` and it will be called inside [wait function](https://github.com/invisibleroads/socketIO-client/blob/master/socketIO_client/__init__.py#L266).
Not using namespace will use default [on_disconnect](https://github.com/invisibleroads/socketIO-client/blob/master/socketIO_client/namespaces.py#L108) and even if you do something like:
```code
socketIO = SocketIO('localhost', 8000)
socketIO.on('on_disconnect', my_function)
```
will not work, because it will not try to find callbacks from `_callback_by_event `.
Calling disconnect function using `_find_packet_callback("disconnect")()` will emulate what user wants to do when io gets disconnected.
That would solve also #107, #127, #98.