### PR TITLE
Fix websocket-client library incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         'requests>=2.7.0',
         'six',
-        'websocket-client',
+        'websocket-client==0.37.0',
     ],
     tests_require=[
         'nose',


### PR DESCRIPTION
websocket-client dependency have been updated and create conflicts with SocketIO-client.
Error Log:

>>> from socketIO_client import SocketIO
An incompatible websocket library is conflicting with the one we need.
You can remove the incompatible library and install the correct one
by running the following commands:

yes | pip uninstall websocket websocket-client
pip install -U websocket-client

So, just set previous version of websocket-client on setup.py.

It works fine =)