### PR TITLE
Add compatibility with websocket-client>=0.39.0

### DIFF
--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -8,8 +8,9 @@ from six.moves.urllib.parse import urlparse as parse_url
 from socket import error as SocketError
 try:
     from websocket import (
-        SSLError, WebSocketConnectionClosedException,
+        WebSocketConnectionClosedException,
         WebSocketTimeoutException, create_connection)
+    from websocket._ssl_compat import SSLError
 except ImportError:
     exit("""\
 An incompatible websocket library is conflicting with the one we need.


### PR DESCRIPTION
SSLError needs to be imported explicitly from its module of definition
now due to imports refactoring.

Note: This change doesn't break compatibility with websocket-client<0.39.0.