### PR TITLE
close http_session and websocket connections when done

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -95,6 +95,7 @@ class EngineIO(LoggingMixin):
                 transport.send_packet(2, 'probe')
                 for packet_type, packet_data in transport.recv_packet():
                     if packet_type == 3 and packet_data == b'probe':
+                        self._transport_instance.http_session.__exit__()
                         transport.send_packet(5, '')
                         self._transport_instance = transport
                         self.transport_name = 'websocket'
@@ -198,9 +199,8 @@ class EngineIO(LoggingMixin):
             pass
         if not hasattr(self, '_opened') or not self._opened:
             return
-        engineIO_packet_type = 1
         try:
-            self._transport_instance.send_packet(engineIO_packet_type)
+            self._transport_instance.close()
         except (TimeoutError, ConnectionError):
             pass
         self._opened = False

--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -47,6 +47,10 @@ class AbstractTransport(object):
     def set_timeout(self, seconds=None):
         pass
 
+    def close(self):
+        # Send the "close" packet type
+        self.send_packet(1)
+
 
 class XHR_PollingTransport(AbstractTransport):
 
@@ -104,6 +108,10 @@ class XHR_PollingTransport(AbstractTransport):
                 int(time.time() * 1000), self._request_index)
             self._request_index += 1
         return timestamp
+
+    def close(self):
+        super(XHR_PollingTransport, self).close()
+        self.http_session.__exit__()
 
 
 class WebsocketTransport(AbstractTransport):
@@ -169,6 +177,10 @@ class WebsocketTransport(AbstractTransport):
 
     def set_timeout(self, seconds=None):
         self._connection.settimeout(seconds or self._timeout)
+
+    def close(self):
+        super(WebsocketTransport, self).close()
+        self._connection.close()
 
 
 def get_response(request, *args, **kw):


### PR DESCRIPTION
I believe this closes #176.  Tests pass and don't leave lingering connections.