### PR TITLE
Failed to connect with server socket.io version 2.x #fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ DESCRIPTION = '\n\n'.join(LOAD_TEXT(_) for _ in [
 ])
 setup(
     name='socketIO-client',
-    version='0.7.2',
+    version='0.7.3',
     description='A socket.io client library',
     long_description=DESCRIPTION,
     license='MIT',

--- a/socketIO_client/parsers.py
+++ b/socketIO_client/parsers.py
@@ -126,7 +126,7 @@ def _read_packet_length(content, content_index):
     content_index += 1
     packet_length_string = ''
     byte = get_byte(content, content_index)
-    while byte != 255:
+    while byte != 255 and byte != ':':
         packet_length_string += str(byte)
         content_index += 1
         byte = get_byte(content, content_index)
@@ -134,7 +134,10 @@ def _read_packet_length(content, content_index):
 
 
 def _read_packet_text(content, content_index, packet_length):
-    while get_byte(content, content_index) == 255:
+    byte = get_byte(content, content_index)
+    while byte == 255 or byte == ':':
         content_index += 1
+        byte = get_byte(content, content_index)
     packet_text = content[content_index:content_index + packet_length]
     return content_index + packet_length, packet_text
+

--- a/socketIO_client/parsers.py
+++ b/socketIO_client/parsers.py
@@ -121,23 +121,37 @@ def _make_packet_prefix(packet):
 
 
 def _read_packet_length(content, content_index):
-    while get_byte(content, content_index) != 0:
+    try:
+        content = content.decode()
+        start = content_index
+        while content[content_index] != ':':
+            content_index += 1
+        packet_length_string = content[start:content_index]
+        return content_index, int(packet_length_string)
+    except:
+        while get_byte(content, content_index) != 0:
+            content_index += 1
         content_index += 1
-    content_index += 1
-    packet_length_string = ''
-    byte = get_byte(content, content_index)
-    while byte != 255 and byte != ':':
-        packet_length_string += str(byte)
-        content_index += 1
+        packet_length_string = ''
         byte = get_byte(content, content_index)
-    return content_index, int(packet_length_string)
+        while byte != 255 and byte != ':':
+            packet_length_string += str(byte)
+            content_index += 1
+            byte = get_byte(content, content_index)
+        return content_index, int(packet_length_string)
 
 
 def _read_packet_text(content, content_index, packet_length):
-    byte = get_byte(content, content_index)
-    while byte == 255 or byte == ':':
-        content_index += 1
+    try:
+        content = content.decode()
+        while content[content_index] == ':':
+            content_index += 1
+        packet_text = content[content_index:content_index + packet_length]
+        return content_index + packet_length, packet_text.encode()
+    except:
         byte = get_byte(content, content_index)
-    packet_text = content[content_index:content_index + packet_length]
-    return content_index + packet_length, packet_text
-
+        while byte == 255 or byte == ':':
+            content_index += 1
+            byte = get_byte(content, content_index)
+        packet_text = content[content_index:content_index + packet_length]
+        return content_index + packet_length, packet_text


### PR DESCRIPTION
I have combined the changes from [Nexus](https://github.com/nexus-devs/socketIO-client-2.0.3) in two functions `_read_packet_text` and  `_read_packet_length` in `parser.py`. So it will work with both 1.x and 2.x server socket.io module versions.