### PR TITLE
Receiving messages (i.e. events with name 'message') now works properly.

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -298,9 +298,12 @@ class EngineIO(LoggingMixin):
         except KeyError:
             raise PacketError(
                 'unexpected engine.io packet type (%s)' % engineIO_packet_type)
-        delegate(engineIO_packet_data, namespace)
+                
         if engineIO_packet_type == 4:
             return engineIO_packet_data
+            
+        delegate(engineIO_packet_data, namespace)
+        
 
     def _on_open(self, data, namespace):
         namespace._find_packet_callback('open')()

--- a/socketIO_client/exceptions.py
+++ b/socketIO_client/exceptions.py
@@ -12,3 +12,7 @@ class PacketError(SocketIOError):
 
 class TimeoutError(SocketIOError):
     pass
+
+
+class AuthorizationError(SocketIOError):
+    pass

--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -21,7 +21,7 @@ pip install -U websocket-client""")
 else:
     from websocket._ssl_compat import SSLError
 
-from .exceptions import ConnectionError, TimeoutError
+from .exceptions import ConnectionError, TimeoutError, AuthorizationError
 from .parsers import (
     encode_engineIO_content, decode_engineIO_content,
     format_packet_text, parse_packet_text)
@@ -183,7 +183,10 @@ def get_response(request, *args, **kw):
     except requests.exceptions.SSLError as e:
         raise ConnectionError('could not negotiate SSL (%s)' % e)
     status_code = response.status_code
+    
     if 200 != status_code:
+        if status_code == 401:
+            raise AuthorizationError('unauthorized')
         raise ConnectionError('unexpected status code (%s %s)' % (
             status_code, response.text))
     return response


### PR DESCRIPTION
`EngineIO._on_message()` seems consider _any_ incoming data (message or event) to be a "message". Before this change handlers specified for 'message' would therefore also receive the raw SocketIO packet.